### PR TITLE
Contribution

### DIFF
--- a/src/flakeref.rs
+++ b/src/flakeref.rs
@@ -65,10 +65,18 @@ impl Display for FlakeRef {
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct FlakeRefParameters {
+    /// The subdirectory of the flake in which flake.nix is located. This parameter
+    /// enables having multiple flakes in a repository or tarball. The default is the
+    /// root directory of the flake.
     dir: Option<String>,
+    /// The hash of the NAR serialisation (in SRI format) of the contents of the flake.
+    /// This is useful for flake types such as tarballs that lack a unique content
+    /// identifier such as a Git commit hash.
     #[serde(rename = "narHash")]
     nar_hash: Option<String>,
+    /// A Git or Mercurial commit hash.
     rev: Option<String>,
+    ///  A Git or Mercurial branch or tag name.
     r#ref: Option<String>,
     branch: Option<String>,
     submodules: Option<String>,

--- a/src/urls.rs
+++ b/src/urls.rs
@@ -8,6 +8,14 @@ pub struct UrlWrapper {
     infer_type: bool,
     explicit_type: FlakeRefType,
 }
+impl TryFrom<&str> for UrlWrapper {
+    type Error = NixUriError;
+
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
+        let url = Url::parse(input)?;
+        Ok(Self::new(url))
+    }
+}
 
 impl UrlWrapper {
     pub(crate) fn new(url: Url) -> Self {
@@ -16,10 +24,6 @@ impl UrlWrapper {
             infer_type: true,
             explicit_type: FlakeRefType::None,
         }
-    }
-    pub(crate) fn from(input: &str) -> NixUriResult<Self> {
-        let url = Url::parse(input)?;
-        Ok(Self::new(url))
     }
     pub fn infer_type(&mut self, infer_type: bool) -> &mut Self {
         self.infer_type = infer_type;
@@ -31,7 +35,7 @@ impl UrlWrapper {
     }
     pub fn convert_or_parse(input: &str) -> NixUriResult<FlakeRef> {
         // If default parsing fails, it might still be a `nix-uri`.
-        let url = Self::from(input).ok();
+        let url = Self::try_from(input).ok();
 
         if is_tarball(input) {
             return input.parse();


### PR DESCRIPTION
This is an initial contribution:

- Adds doc comments based on https://nix.dev/manual/nix/2.18/command-ref/new-cli/nix3-flake#flake-reference-attributes
- Removes a redundant `.collect`
- Removes repeated code
- Renames an enum: differentiate between the paramater-key enum and paramater value struct.