### PR TITLE
deps(fuzz): Update rustix from `0.38.15` -> `0.38.38`

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -309,7 +309,7 @@ checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "rustix"
-version = "0.38.15"
+version = "0.38.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f9da0cbd88f9f09e7814e388301c8414c51c62aa6ce1e4b5c551d49d96e531"
 dependencies = [


### PR DESCRIPTION
Reference:

https://github.com/imsnif/bandwhich/issues/284
