### PR TITLE
build(cargo): Remove now obsolete `parallel-compiler` opt in

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,1 +1,0 @@
-parallel-compiler = true


### PR DESCRIPTION
Remove now obsolete `parallel-compiler` opt in.
It is now on by default.
