### PR TITLE
Integrate attribute path to the flakeref.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,9 @@ pub enum NixUriError {
     /// Generic parsing fail
     #[error("Error parsing: {0}")]
     ParseError(String),
+    /// Invalid Attribute path
+    #[error("Not a valid attribute-path string: {0}")]
+    InvalidAttrPath(String),
     /// Invalid Url
     #[error("Not a valid Url: {0}")]
     InvalidUrl(String),

--- a/src/flakeref.rs
+++ b/src/flakeref.rs
@@ -7,7 +7,7 @@ use nom::{
 };
 use serde::{Deserialize, Serialize};
 
-mod attr_path;
+pub(crate) mod attr_path;
 
 use crate::{
     error::{NixUriError, NixUriResult},
@@ -600,6 +600,7 @@ impl std::str::FromStr for FlakeRef {
     type Err = NixUriError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        println!("input: {}", s);
         use crate::parser::parse_nix_uri;
         parse_nix_uri(s)
     }
@@ -623,19 +624,24 @@ mod tests {
         let parsed: FlakeRef = uri.try_into().unwrap();
         assert_eq!(expected, parsed);
     }
-    // #[test]
-    // fn parse_simple_uri_attr() {
-    //     let uri = "github:nixos/nixpkgs#foo";
-    //     let expected = FlakeRef::default()
-    //         .r#type(FlakeRefType::GitHub {
-    //             owner: "nixos".into(),
-    //             repo: "nixpkgs".into(),
-    //             ref_or_rev: None,
-    //         })
-    //         .clone();
-    //     let parsed: FlakeRef = uri.try_into().unwrap();
-    //     assert_eq!(expected, parsed);
-    // }
+    #[test]
+    fn parse_simple_uri_attr() {
+        let uri = "github:nixos/nixpkgs#foo";
+        let mut expected = FlakeRef {
+            r#type: FlakeRefType::GitHub {
+                owner: "nixos".into(),
+                repo: "nixpkgs".into(),
+                ref_or_rev: None,
+            },
+            attributes: Some(attr_path::AttrPath {
+                attrs: vec!["foo".to_string()],
+            }),
+            ..Default::default()
+        };
+
+        let parsed: FlakeRef = uri.try_into().unwrap();
+        assert_eq!(expected, parsed);
+    }
 
     #[test]
     fn parse_simple_uri_parsed() {

--- a/src/flakeref/attr_path.rs
+++ b/src/flakeref/attr_path.rs
@@ -1,0 +1,16 @@
+use std::fmt::Display;
+
+use serde::{Deserialize, Serialize};
+
+/// A non-empty vector of strings that make up the attribute path
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AttrPath {
+    attrs: Vec<String>
+}
+
+
+impl Display for AttrPath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.attrs.as_slice().join("."))
+    }
+}

--- a/src/flakeref/attr_path.rs
+++ b/src/flakeref/attr_path.rs
@@ -1,16 +1,33 @@
 use std::fmt::Display;
 
+use nom::{
+    bytes::complete::{tag, take_till},
+    IResult,
+};
 use serde::{Deserialize, Serialize};
+
+use crate::NixUriError;
 
 /// A non-empty vector of strings that make up the attribute path
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AttrPath {
-    attrs: Vec<String>
+    pub(crate) attrs: Vec<String>,
 }
-
 
 impl Display for AttrPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.attrs.as_slice().join("."))
+    }
+}
+
+impl std::str::FromStr for AttrPath {
+    type Err = NixUriError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.contains('"') || s.contains('#') || s.is_empty() {
+            return Err(NixUriError::InvalidAttrPath(s.to_string()));
+        }
+        let attrs = s.split('.').map(|s| s.to_string()).collect::<Vec<_>>();
+        Ok(Self { attrs })
     }
 }


### PR DESCRIPTION
The idea here is that appending `#....` to the flake ref will parse `....` into an attribute path.