### PR TITLE
nix/rust: Use stable rust version for `rustfmt`

### DIFF
--- a/.rust-nightly-toolchain.toml
+++ b/.rust-nightly-toolchain.toml
@@ -1,5 +1,0 @@
-# This file is updated by the `akenji@update-rust-toolchain` GitHub action
-[toolchain]
-channel = "nightly-2023-12-10"
-components = ["rustfmt"]
-targets = []

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -44,8 +44,6 @@ There is a lint target in the `justfile`, that can be run with:
 ```
 just lint
 ```
-
-The `rustfmt` version is referenced inside the `.rustfmt-toolchain.toml`.
 The `clippy` version is referenced inside `rust-toolchain.toml`, only lints targeting that version will be merged.
 
 ## Running Benchmarks

--- a/nix/devshells.nix
+++ b/nix/devshells.nix
@@ -39,7 +39,7 @@
           name = "nix-uri-nightly-fuzz";
           inputsFrom = [ self'.devShells.default ];
           packages = [
-            rust.rustNightlyToolchainTOML
+            rust.rustLatestNightlyToolchain
             pkgs.cargo-fuzz
           ];
           inherit env;

--- a/nix/rust.nix
+++ b/nix/rust.nix
@@ -5,11 +5,10 @@
 }:
 let
   RUST_TOOLCHAIN = self + "/rust-toolchain.toml";
-  RUST_NIGHTLY_TOOLCHAIN = self + "/.rust-nightly-toolchain.toml";
 in
 rec {
   rustToolchainTOML = pkgs.rust-bin.fromRustupToolchainFile RUST_TOOLCHAIN;
-  rustNightlyToolchainTOML = pkgs.rust-bin.fromRustupToolchainFile RUST_NIGHTLY_TOOLCHAIN;
+  rustLatestNightlyToolchain = pkgs.rust-bin.selectLatestNightlyWith (toolchain: toolchain.default);
   rustToolchainDevTOML = rustToolchainTOML.override {
     extensions = [
       "clippy"


### PR DESCRIPTION
Use stable rust version for `rustfmt`, only the fuzz targets depend on a
nightly toolchain now.
