### PR TITLE
Resource flatten

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -37,6 +37,8 @@ pub enum NixUriError {
     InvalidType(String),
     #[error("The parameter: {0} is not supported by the flakeref type.")]
     UnsupportedParam(String),
+    #[error("field: `{0}` only supported by: `{1}`.")]
+    UnsupportedByType(String, String),
     #[error("The parameter: {0} invalid.")]
     UnknownUriParameter(String),
     /// Nom Error

--- a/src/flakeref.rs
+++ b/src/flakeref.rs
@@ -23,6 +23,7 @@ mod transport_layer;
 pub use transport_layer::TransportLayer;
 mod forge;
 pub use forge::{GitForge, GitForgePlatform};
+mod resource_url;
 
 /// The General Flake Ref Schema
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -108,7 +109,7 @@ impl std::str::FromStr for FlakeRef {
 mod inc_parse {
     use std::path::PathBuf;
 
-    use fr_type::{ResourceType, ResourceUrl};
+    use resource_url::{ResourceType, ResourceUrl};
 
     use super::*;
     #[test]
@@ -150,7 +151,8 @@ mod inc_parse {
 
 #[cfg(test)]
 mod tests {
-    use fr_type::{ResourceType, ResourceUrl};
+
+    use resource_url::{ResourceType, ResourceUrl};
 
     use super::*;
     use crate::parser::{parse_nix_uri, parse_params};

--- a/src/flakeref.rs
+++ b/src/flakeref.rs
@@ -108,6 +108,8 @@ impl std::str::FromStr for FlakeRef {
 mod inc_parse {
     use std::path::PathBuf;
 
+    use fr_type::{ResourceType, ResourceUrl};
+
     use super::*;
     #[test]
     fn full_github() {
@@ -132,9 +134,11 @@ mod inc_parse {
         let uri = "file:///phantom/root/path?dir=foo#fizz.buzz";
         let (rest, parse_out) = FlakeRef::parse(uri).unwrap();
         let mut expected = FlakeRef::default();
-        expected.r#type(FlakeRefType::File {
-            location: PathBuf::from("/phantom/root/path"),
-        });
+        expected.r#type(FlakeRefType::Resource(ResourceUrl {
+            res_type: ResourceType::File,
+            location: "/phantom/root/path".to_string(),
+            transport_type: None,
+        }));
         let mut exp_params = LocationParameters::default();
         exp_params.dir(Some("foo".to_string()));
         expected.params = exp_params;
@@ -146,6 +150,8 @@ mod inc_parse {
 
 #[cfg(test)]
 mod tests {
+    use fr_type::{ResourceType, ResourceUrl};
+
     use super::*;
     use crate::parser::{parse_nix_uri, parse_params};
 
@@ -452,10 +458,11 @@ mod tests {
     fn parse_git_and_https_simple() {
         let uri = "git+https://git.somehost.tld/user/path";
         let expected = FlakeRef::default()
-            .r#type(FlakeRefType::Git {
+            .r#type(FlakeRefType::Resource(ResourceUrl {
+                res_type: ResourceType::Git,
                 location: "git.somehost.tld/user/path".into(),
-                transport_type: TransportLayer::Https,
-            })
+                transport_type: Some(TransportLayer::Https),
+            }))
             .clone();
         let parsed: FlakeRef = uri.try_into().unwrap();
         assert_eq!(expected, parsed);
@@ -470,10 +477,11 @@ mod tests {
         params.r#ref(Some("branch".into()));
         params.rev(Some("fdc8ef970de2b4634e1b3dca296e1ed918459a9e".into()));
         let expected = FlakeRef::default()
-            .r#type(FlakeRefType::Git {
+            .r#type(FlakeRefType::Resource(ResourceUrl {
+                res_type: ResourceType::Git,
                 location: "git.somehost.tld/user/path".into(),
-                transport_type: TransportLayer::Https,
-            })
+                transport_type: Some(TransportLayer::Https),
+            }))
             .params(params)
             .clone();
         let parsed: FlakeRef = uri.try_into().unwrap();
@@ -488,26 +496,36 @@ mod tests {
         let mut params = LocationParameters::default();
         params.r#ref(Some("upstream/nixpkgs-unstable".into()));
         let expected = FlakeRef::default()
-            .r#type(FlakeRefType::Git {
+            .r#type(FlakeRefType::Resource(ResourceUrl {
+                res_type: ResourceType::Git,
                 location: "/nix/nixpkgs".into(),
-                transport_type: TransportLayer::File,
-            })
-            .params(params)
+                transport_type: Some(TransportLayer::File),
+            }))
+            .params(params.clone())
             .clone();
         let parsed: FlakeRef = uri.try_into().unwrap();
         assert_eq!(expected, parsed);
         let (rest, nommed) = FlakeRef::parse(uri).unwrap();
         assert_eq!("", rest);
+        let expected = FlakeRef::default()
+            .r#type(FlakeRefType::Resource(ResourceUrl {
+                res_type: ResourceType::Git,
+                location: "/nix/nixpkgs".into(),
+                transport_type: None,
+            }))
+            .params(params.clone())
+            .clone();
         assert_eq!(expected, nommed);
     }
     #[test]
     fn parse_git_and_file_simple() {
         let uri = "git+file:///nix/nixpkgs";
         let expected = FlakeRef::default()
-            .r#type(FlakeRefType::Git {
+            .r#type(FlakeRefType::Resource(ResourceUrl {
+                res_type: ResourceType::Git,
                 location: "/nix/nixpkgs".into(),
-                transport_type: TransportLayer::File,
-            })
+                transport_type: Some(TransportLayer::File),
+            }))
             .clone();
         let parsed: FlakeRef = uri.try_into().unwrap();
         assert_eq!(expected, parsed);
@@ -523,10 +541,11 @@ mod tests {
         let mut params = LocationParameters::default();
         params.set_branch(Some("feat/myNewFeature".into()));
         let expected = FlakeRef::default()
-            .r#type(FlakeRefType::Git {
+            .r#type(FlakeRefType::Resource(ResourceUrl {
+                res_type: ResourceType::Git,
                 location: "/home/user/forked-flake".into(),
-                transport_type: TransportLayer::File,
-            })
+                transport_type: Some(TransportLayer::File),
+            }))
             .params(params)
             .clone();
         let parsed: FlakeRef = uri.try_into().unwrap();
@@ -579,10 +598,11 @@ mod tests {
         let mut params = LocationParameters::default();
         params.set_branch(Some("feat/myNewFeature".into()));
         let expected = FlakeRef::default()
-            .r#type(FlakeRefType::Git {
+            .r#type(FlakeRefType::Resource(ResourceUrl {
+                res_type: ResourceType::Git,
                 location: "/home/user/forked-flake".into(),
-                transport_type: TransportLayer::File,
-            })
+                transport_type: Some(TransportLayer::File),
+            }))
             .params(params)
             .clone();
         let parsed: FlakeRef = uri.try_into().unwrap();
@@ -617,10 +637,11 @@ mod tests {
         let mut params = LocationParameters::default();
         params.set_submodules(Some("1".into()));
         let expected = FlakeRef::default()
-            .r#type(FlakeRefType::Git {
+            .r#type(FlakeRefType::Resource(ResourceUrl {
+                res_type: ResourceType::Git,
                 location: "www.github.com/ocaml/ocaml-lsp".to_owned(),
-                transport_type: TransportLayer::Https,
-            })
+                transport_type: Some(TransportLayer::Https),
+            }))
             .params(params)
             .clone();
         let parsed: FlakeRef = uri.try_into().unwrap();
@@ -634,10 +655,11 @@ mod tests {
         let uri = "hg+https://www.github.com/ocaml/ocaml-lsp";
         let mut params = LocationParameters::default();
         let expected = FlakeRef::default()
-            .r#type(FlakeRefType::Mercurial {
+            .r#type(FlakeRefType::Resource(ResourceUrl {
+                res_type: ResourceType::Mercurial,
                 location: "www.github.com/ocaml/ocaml-lsp".to_owned(),
-                transport_type: TransportLayer::Https,
-            })
+                transport_type: Some(TransportLayer::Https),
+            }))
             .clone();
         let parsed: FlakeRef = uri.try_into().unwrap();
         assert_eq!(expected, parsed);
@@ -652,10 +674,11 @@ mod tests {
         let mut params = LocationParameters::default();
         params.set_submodules(Some("1".into()));
         let expected = FlakeRef::default()
-            .r#type(FlakeRefType::Git {
+            .r#type(FlakeRefType::Resource(ResourceUrl {
+                res_type: ResourceType::Git,
                 location: "www.github.com/ocaml/ocaml-lsp".to_owned(),
-                transport_type: TransportLayer::Https,
-            })
+                transport_type: Some(TransportLayer::Https),
+            }))
             .params(params)
             .clone();
         let parsed: FlakeRef = uri.try_into().unwrap();
@@ -671,10 +694,11 @@ mod tests {
         let mut params = LocationParameters::default();
         params.set_shallow(Some("1".into()));
         let expected = FlakeRef::default()
-            .r#type(FlakeRefType::Git {
+            .r#type(FlakeRefType::Resource(ResourceUrl {
+                res_type: ResourceType::Git,
                 location: "/path/to/repo".to_owned(),
-                transport_type: TransportLayer::File,
-            })
+                transport_type: Some(TransportLayer::File),
+            }))
             .params(params)
             .clone();
         let parsed: FlakeRef = uri.try_into().unwrap();

--- a/src/flakeref.rs
+++ b/src/flakeref.rs
@@ -486,10 +486,12 @@ mod tests {
             }))
             .params(params)
             .clone();
+
         let parsed: FlakeRef = uri.try_into().unwrap();
-        assert_eq!(expected, parsed);
         let (rest, nommed) = FlakeRef::parse(uri).unwrap();
+
         assert_eq!("", rest);
+        assert_eq!(expected, parsed);
         assert_eq!(expected, nommed);
     }
     #[test]
@@ -505,18 +507,12 @@ mod tests {
             }))
             .params(params.clone())
             .clone();
+
         let parsed: FlakeRef = uri.try_into().unwrap();
-        assert_eq!(expected, parsed);
         let (rest, nommed) = FlakeRef::parse(uri).unwrap();
+
         assert_eq!("", rest);
-        // let expected = FlakeRef::default()
-        //     .r#type(FlakeRefType::Resource(ResourceUrl {
-        //         res_type: ResourceType::Git,
-        //         location: "/nix/nixpkgs".into(),
-        //         transport_type: None,
-        //     }))
-        //     .params(params.clone())
-        //     .clone();
+        assert_eq!(expected, parsed);
         assert_eq!(expected, nommed);
     }
     #[test]
@@ -530,9 +526,10 @@ mod tests {
             }))
             .clone();
         let parsed: FlakeRef = uri.try_into().unwrap();
-        assert_eq!(expected, parsed);
         let (rest, nommed) = FlakeRef::parse(uri).unwrap();
+
         assert_eq!("", rest);
+        assert_eq!(expected, parsed);
         assert_eq!(expected, nommed);
     }
     #[test]
@@ -551,9 +548,10 @@ mod tests {
             .params(params)
             .clone();
         let parsed: FlakeRef = uri.try_into().unwrap();
-        assert_eq!(expected, parsed);
         let (rest, nommed) = FlakeRef::parse(uri).unwrap();
+
         assert_eq!("", rest);
+        assert_eq!(expected, parsed);
         assert_eq!(expected, nommed);
     }
     #[test]
@@ -571,9 +569,10 @@ mod tests {
             .params(params)
             .clone();
         let parsed: FlakeRef = uri.try_into().unwrap();
-        assert_eq!(expected, parsed);
         let (rest, nommed) = FlakeRef::parse(uri).unwrap();
+
         assert_eq!("", rest);
+        assert_eq!(expected, parsed);
         assert_eq!(expected, nommed);
     }
     #[test]
@@ -589,9 +588,10 @@ mod tests {
             }))
             .clone();
         let parsed: FlakeRef = uri.try_into().unwrap();
-        assert_eq!(expected, parsed);
         let (rest, nommed) = FlakeRef::parse(uri).unwrap();
+
         assert_eq!("", rest);
+        assert_eq!(expected, parsed);
         assert_eq!(expected, nommed);
     }
     #[test]
@@ -608,9 +608,10 @@ mod tests {
             .params(params)
             .clone();
         let parsed: FlakeRef = uri.try_into().unwrap();
-        assert_eq!(expected, parsed);
         let (rest, nommed) = FlakeRef::parse(uri).unwrap();
+
         assert_eq!("", rest);
+        assert_eq!(expected, parsed);
         assert_eq!(expected, nommed);
     }
     #[test]
@@ -628,9 +629,10 @@ mod tests {
             .params(params)
             .clone();
         let parsed: FlakeRef = uri.try_into().unwrap();
-        assert_eq!(expected, parsed);
         let (rest, nommed) = FlakeRef::parse(uri).unwrap();
+
         assert_eq!("", rest);
+        assert_eq!(expected, parsed);
         assert_eq!(expected, nommed);
     }
     #[test]
@@ -647,9 +649,10 @@ mod tests {
             .params(params)
             .clone();
         let parsed: FlakeRef = uri.try_into().unwrap();
-        assert_eq!(expected, parsed);
         let (rest, nommed) = FlakeRef::parse(uri).unwrap();
+
         assert_eq!("", rest);
+        assert_eq!(expected, parsed);
         assert_eq!(expected, nommed);
     }
     #[test]
@@ -664,9 +667,10 @@ mod tests {
             }))
             .clone();
         let parsed: FlakeRef = uri.try_into().unwrap();
-        assert_eq!(expected, parsed);
         let (rest, nommed) = FlakeRef::parse(uri).unwrap();
+
         assert_eq!("", rest);
+        assert_eq!(expected, parsed);
         assert_eq!(expected, nommed);
     }
     #[test]
@@ -684,9 +688,10 @@ mod tests {
             .params(params)
             .clone();
         let parsed: FlakeRef = uri.try_into().unwrap();
-        assert_eq!(expected, parsed);
         let (rest, nommed) = FlakeRef::parse(uri).unwrap();
+
         assert_eq!("", rest);
+        assert_eq!(expected, parsed);
         assert_eq!(expected, nommed);
     }
     // TODO: https://github.com/a-kenji/nix-uri/issues/157
@@ -746,9 +751,10 @@ mod tests {
             }))
             .clone();
         let parsed: FlakeRef = uri.try_into().unwrap();
-        assert_eq!(expected, parsed);
         let (rest, nommed) = FlakeRef::parse(uri).unwrap();
+
         assert_eq!("", rest);
+        assert_eq!(expected, parsed);
         assert_eq!(expected, nommed);
     }
     #[test]
@@ -763,9 +769,10 @@ mod tests {
             }))
             .clone();
         let parsed: FlakeRef = uri.try_into().unwrap();
-        assert_eq!(expected, parsed);
         let (rest, nommed) = FlakeRef::parse(uri).unwrap();
+
         assert_eq!("", rest);
+        assert_eq!(expected, parsed);
         assert_eq!(expected, nommed);
     }
     #[test]
@@ -783,9 +790,10 @@ mod tests {
             .params(params)
             .clone();
         let parsed: FlakeRef = uri.try_into().unwrap();
-        assert_eq!(expected, parsed);
         let (rest, nommed) = FlakeRef::parse(uri).unwrap();
+
         assert_eq!("", rest);
+        assert_eq!(expected, parsed);
         assert_eq!(expected, nommed);
     }
     #[test]
@@ -800,9 +808,10 @@ mod tests {
             }))
             .clone();
         let parsed: FlakeRef = uri.try_into().unwrap();
-        assert_eq!(expected, parsed);
         let (rest, nommed) = FlakeRef::parse(uri).unwrap();
+
         assert_eq!("", rest);
+        assert_eq!(expected, parsed);
         assert_eq!(expected, nommed);
     }
     #[test]
@@ -821,9 +830,10 @@ mod tests {
             .params(params)
             .clone();
         let parsed: FlakeRef = uri.try_into().unwrap();
-        assert_eq!(expected, parsed);
         let (rest, nommed) = FlakeRef::parse(uri).unwrap();
+
         assert_eq!("", rest);
+        assert_eq!(expected, parsed);
         assert_eq!(expected, nommed);
     }
     #[test]
@@ -897,9 +907,10 @@ mod tests {
             })
             .clone();
         let parsed: FlakeRef = uri.try_into().unwrap();
-        assert_eq!(expected, parsed);
         let (rest, nommed) = FlakeRef::parse(uri).unwrap();
+
         assert_eq!("", rest);
+        assert_eq!(expected, parsed);
         assert_eq!(expected, nommed);
     }
     #[test]
@@ -914,9 +925,10 @@ mod tests {
             .params(params)
             .clone();
         let parsed: FlakeRef = uri.try_into().unwrap();
-        assert_eq!(expected, parsed);
         let (rest, nommed) = FlakeRef::parse(uri).unwrap();
+
         assert_eq!("", rest);
+        assert_eq!(expected, parsed);
         assert_eq!(expected, nommed);
     }
 

--- a/src/flakeref.rs
+++ b/src/flakeref.rs
@@ -507,14 +507,14 @@ mod tests {
         assert_eq!(expected, parsed);
         let (rest, nommed) = FlakeRef::parse(uri).unwrap();
         assert_eq!("", rest);
-        let expected = FlakeRef::default()
-            .r#type(FlakeRefType::Resource(ResourceUrl {
-                res_type: ResourceType::Git,
-                location: "/nix/nixpkgs".into(),
-                transport_type: None,
-            }))
-            .params(params.clone())
-            .clone();
+        // let expected = FlakeRef::default()
+        //     .r#type(FlakeRefType::Resource(ResourceUrl {
+        //         res_type: ResourceType::Git,
+        //         location: "/nix/nixpkgs".into(),
+        //         transport_type: None,
+        //     }))
+        //     .params(params.clone())
+        //     .clone();
         assert_eq!(expected, nommed);
     }
     #[test]

--- a/src/flakeref/fr_type.rs
+++ b/src/flakeref/fr_type.rs
@@ -18,7 +18,10 @@ use crate::{
     parser::{parse_sep, parse_transport_type},
 };
 
-use super::{GitForgePlatform, TransportLayer};
+use super::{
+    resource_url::{ResourceType, ResourceUrl},
+    GitForgePlatform, TransportLayer,
+};
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum FlakeRefType {
@@ -38,60 +41,6 @@ pub enum FlakeRefType {
     None,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct ResourceUrl {
-    pub res_type: ResourceType,
-    pub location: String,
-    pub transport_type: Option<TransportLayer>,
-}
-
-impl ResourceUrl {
-    pub fn parse(input: &str) -> IResult<&str, Self> {
-        let (rest, res_type) = ResourceType::parse(input)?;
-        let (rest, transport_type) = opt(TransportLayer::plus_parse)(rest)?;
-        let (rest, _tag) = parse_sep(rest)?;
-        let (res, location) = take_till(|c| c == '#' || c == '?')(rest)?;
-
-        Ok((
-            res,
-            Self {
-                res_type,
-                location: location.to_string(),
-                transport_type,
-            },
-        ))
-    }
-}
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub enum ResourceType {
-    Git,
-    Mercurial,
-    File,
-    Tarball,
-}
-
-impl ResourceType {
-    pub fn parse(input: &str) -> IResult<&str, Self> {
-        alt((
-            map(tag("git"), |_| Self::Git),
-            map(tag("hg"), |_| Self::Mercurial),
-            map(tag("file"), |_| Self::File),
-            map(tag("tarball"), |_| Self::Tarball),
-        ))(input)
-    }
-}
-
-impl Display for ResourceType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let out_str = match self {
-            Self::Git => "git",
-            Self::Mercurial => "mercurial",
-            Self::File => "file",
-            Self::Tarball => "tarball",
-        };
-        write!(f, "{}", out_str)
-    }
-}
 impl FlakeRefType {
     // TODO: #158
     pub fn parse_file(input: &str) -> IResult<&str, Self> {

--- a/src/flakeref/fr_type.rs
+++ b/src/flakeref/fr_type.rs
@@ -317,6 +317,31 @@ impl Display for FlakeRefType {
 #[cfg(test)]
 mod inc_parse_vc {
     use super::*;
+
+    #[test]
+    fn parse_git_github_collision() {
+        let hub = "github:foo/bar";
+        let git = "git:///foo/bar";
+        let (rest_hub, parsed_hub) = FlakeRefType::parse(hub).unwrap();
+        let (rest_git, parsed_git) = FlakeRefType::parse(git).unwrap();
+        let expected_hub = FlakeRefType::GitForge(GitForge {
+            platform: GitForgePlatform::GitHub,
+            owner: "foo".to_string(),
+            repo: "bar".to_string(),
+            ref_or_rev: None,
+        });
+        let expected_git = FlakeRefType::Resource(ResourceUrl {
+            res_type: ResourceType::Git,
+            location: "/foo/bar".to_string(),
+            transport_type: None,
+        });
+
+        assert_eq!("", rest_hub);
+        assert_eq!("", rest_git);
+        assert_eq!(expected_git, parsed_git);
+        assert_eq!(expected_hub, parsed_hub);
+    }
+
     #[test]
     fn git_file() {
         let uri = "git:///foo/bar";

--- a/src/flakeref/resource_url.rs
+++ b/src/flakeref/resource_url.rs
@@ -1,0 +1,68 @@
+use std::fmt::Display;
+
+use nom::{
+    branch::alt,
+    bytes::complete::{tag, take_till},
+    combinator::{map, opt},
+    IResult,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::parser::parse_sep;
+
+use super::TransportLayer;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResourceUrl {
+    pub res_type: ResourceType,
+    pub location: String,
+    pub transport_type: Option<TransportLayer>,
+}
+
+impl ResourceUrl {
+    pub fn parse(input: &str) -> IResult<&str, Self> {
+        let (rest, res_type) = ResourceType::parse(input)?;
+        let (rest, transport_type) = opt(TransportLayer::plus_parse)(rest)?;
+        let (rest, _tag) = parse_sep(rest)?;
+        let (res, location) = take_till(|c| c == '#' || c == '?')(rest)?;
+
+        Ok((
+            res,
+            Self {
+                res_type,
+                location: location.to_string(),
+                transport_type,
+            },
+        ))
+    }
+}
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ResourceType {
+    Git,
+    Mercurial,
+    File,
+    Tarball,
+}
+
+impl ResourceType {
+    pub fn parse(input: &str) -> IResult<&str, Self> {
+        alt((
+            map(tag("git"), |_| Self::Git),
+            map(tag("hg"), |_| Self::Mercurial),
+            map(tag("file"), |_| Self::File),
+            map(tag("tarball"), |_| Self::Tarball),
+        ))(input)
+    }
+}
+
+impl Display for ResourceType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let out_str = match self {
+            Self::Git => "git",
+            Self::Mercurial => "mercurial",
+            Self::File => "file",
+            Self::Tarball => "tarball",
+        };
+        write!(f, "{}", out_str)
+    }
+}

--- a/src/flakeref/resource_url.rs
+++ b/src/flakeref/resource_url.rs
@@ -66,3 +66,23 @@ impl Display for ResourceType {
         write!(f, "{}", out_str)
     }
 }
+
+#[cfg(test)]
+mod res_url {
+    use super::*;
+    #[test]
+    fn git() {
+        let url = "gitfoobar";
+        let (rest, parsed) = ResourceType::parse(url).unwrap();
+        let expected = ResourceType::Git;
+        assert_eq!(expected, parsed);
+        assert_eq!("foobar", rest);
+    }
+    #[test]
+    #[ignore = "need to impl good error handling"]
+    fn gat() {
+        let url = "gat";
+        let err = ResourceType::parse(url).unwrap_err();
+        todo!("Imple informative errors");
+    }
+}

--- a/src/flakeref/transport_layer.rs
+++ b/src/flakeref/transport_layer.rs
@@ -139,4 +139,3 @@ mod err_msg {
         // todo!("Impl informative errors");
     }
 }
-

--- a/src/flakeref/transport_layer.rs
+++ b/src/flakeref/transport_layer.rs
@@ -4,6 +4,7 @@ use nom::{
     branch::alt,
     bytes::complete::{tag, take_until},
     combinator::{map, opt, rest},
+    sequence::preceded,
     IResult,
 };
 use serde::{Deserialize, Serialize};
@@ -28,10 +29,14 @@ impl TransportLayer {
     /// TODO: refactor so None is not in TransportLayer. Use Option to encapsulate this
     pub fn parse(input: &str) -> IResult<&str, Self> {
         alt((
-            map(tag("+https"), |_| TransportLayer::Https),
-            map(tag("+ssh"), |_| TransportLayer::Ssh),
-            map(tag("+file"), |_| TransportLayer::File),
+            map(tag("https"), |_| TransportLayer::Https),
+            map(tag("http"), |_| TransportLayer::Https),
+            map(tag("ssh"), |_| TransportLayer::Ssh),
+            map(tag("file"), |_| TransportLayer::File),
         ))(input)
+    }
+    pub(crate) fn plus_parse(input: &str) -> IResult<&str, Self> {
+        preceded(tag("+"), Self::parse)(input)
     }
 }
 

--- a/src/flakeref/transport_layer.rs
+++ b/src/flakeref/transport_layer.rs
@@ -30,7 +30,7 @@ impl TransportLayer {
     pub fn parse(input: &str) -> IResult<&str, Self> {
         alt((
             map(tag("https"), |_| TransportLayer::Https),
-            map(tag("http"), |_| TransportLayer::Https),
+            map(tag("http"), |_| TransportLayer::Http),
             map(tag("ssh"), |_| TransportLayer::Ssh),
             map(tag("file"), |_| TransportLayer::File),
         ))(input)
@@ -74,23 +74,23 @@ mod inc_parse {
     #[test]
     fn basic() {
         let uri = "+https://";
-        let (rest, tp) = TransportLayer::parse(uri).unwrap();
+        let (rest, tp) = TransportLayer::plus_parse(uri).unwrap();
         assert_eq!(tp, TransportLayer::Https);
         assert_eq!(rest, "://");
 
         let uri = "+ssh://";
-        let (rest, tp) = TransportLayer::parse(uri).unwrap();
+        let (rest, tp) = TransportLayer::plus_parse(uri).unwrap();
         assert_eq!(tp, TransportLayer::Ssh);
         assert_eq!(rest, "://");
 
         let uri = "+file://";
-        let (rest, tp) = TransportLayer::parse(uri).unwrap();
+        let (rest, tp) = TransportLayer::plus_parse(uri).unwrap();
         assert_eq!(tp, TransportLayer::File);
         assert_eq!(rest, "://");
 
         // TODO: #158
         let uri = "://";
-        let nom::Err::Error(e) = TransportLayer::parse(uri).unwrap_err() else {
+        let nom::Err::Error(e) = TransportLayer::plus_parse(uri).unwrap_err() else {
             panic!();
         };
         assert_eq!(e.input, "://");

--- a/src/flakeref/transport_layer.rs
+++ b/src/flakeref/transport_layer.rs
@@ -73,6 +73,11 @@ mod inc_parse {
     use super::*;
     #[test]
     fn basic() {
+        let uri = "+http://";
+        let (rest, tp) = TransportLayer::plus_parse(uri).unwrap();
+        assert_eq!(tp, TransportLayer::Http);
+        assert_eq!(rest, "://");
+
         let uri = "+https://";
         let (rest, tp) = TransportLayer::plus_parse(uri).unwrap();
         assert_eq!(tp, TransportLayer::Https);
@@ -94,5 +99,21 @@ mod inc_parse {
             panic!();
         };
         assert_eq!(e.input, "://");
+    }
+
+    // NOTE: at time of writing this comment, we use `nom`s `alt` combinator to parse `+....`. It
+    // works more like a c-style switch-case than a rust `match`: This is to guard against
+    // regression tests, where we try and parse the `http` before `https`.
+    #[test]
+    fn http_s() {
+        let http = "+httpfoobar";
+        let https = "+httpsfoobar";
+        let (rest, http_parsed) = TransportLayer::plus_parse(http).unwrap();
+        let (rest, https_parsed) = TransportLayer::plus_parse(https).unwrap();
+        let http_expected = TransportLayer::Http;
+        let https_expected = TransportLayer::Https;
+        assert_eq!(http_expected, http_parsed);
+        assert_eq!(https_expected, https_parsed);
+        assert_eq!("foobar", rest);
     }
 }

--- a/src/flakeref/transport_layer.rs
+++ b/src/flakeref/transport_layer.rs
@@ -35,7 +35,7 @@ impl TransportLayer {
             map(tag("file"), |_| TransportLayer::File),
         ))(input)
     }
-    pub(crate) fn plus_parse(input: &str) -> IResult<&str, Self> {
+    pub fn plus_parse(input: &str) -> IResult<&str, Self> {
         preceded(tag("+"), Self::parse)(input)
     }
 }
@@ -117,3 +117,26 @@ mod inc_parse {
         assert_eq!("foobar", rest);
     }
 }
+
+#[cfg(test)]
+mod err_msg {
+    use super::*;
+    #[test]
+    #[ignore = "need to impl good error handling"]
+    fn fizzbuzz() {
+        let url = "+fizzbuzz";
+        let err = TransportLayer::plus_parse(url).unwrap_err();
+        todo!("Impl informative errors");
+    }
+
+    #[test]
+    #[ignore = "need to impl good error handling"]
+    fn missing() {
+        let url = "+";
+        let plus_err = TransportLayer::plus_parse(url).unwrap_err();
+        let err = TransportLayer::parse("").unwrap_err();
+        assert_eq!(plus_err, err);
+        // todo!("Impl informative errors");
+    }
+}
+

--- a/src/flakeref/transport_layer.rs
+++ b/src/flakeref/transport_layer.rs
@@ -29,10 +29,10 @@ impl TransportLayer {
     /// TODO: refactor so None is not in TransportLayer. Use Option to encapsulate this
     pub fn parse(input: &str) -> IResult<&str, Self> {
         alt((
-            map(tag("https"), |_| TransportLayer::Https),
-            map(tag("http"), |_| TransportLayer::Http),
-            map(tag("ssh"), |_| TransportLayer::Ssh),
-            map(tag("file"), |_| TransportLayer::File),
+            map(tag("https"), |_| Self::Https),
+            map(tag("http"), |_| Self::Http),
+            map(tag("ssh"), |_| Self::Ssh),
+            map(tag("file"), |_| Self::File),
         ))(input)
     }
     pub fn plus_parse(input: &str) -> IResult<&str, Self> {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -109,6 +109,10 @@ pub(crate) fn parse_transport_type(input: &str) -> Result<TransportLayer, NixUri
     TryInto::<TransportLayer>::try_into(input)
 }
 
+pub(crate) fn parse_sep(input: &str) -> IResult<&str, &str> {
+    tag("://")(input)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Similarly to git-forge flattening, this PR flattens Git, Mercurial, File and Tarball into a single `url-resource` variant under the `FlakeRef` enum.

In the process, the parsers become a bit more granular in nature, and are moving things towards a code base that should help with setting up informative errors. 