### PR TITLE
Experimental/research work to find a nice error-handling idiom.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
+name = "bytecount"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,6 +315,7 @@ version = "0.1.9"
 dependencies = [
  "criterion",
  "nom",
+ "nom_locate",
  "serde",
  "thiserror",
  "tracing",
@@ -331,6 +338,17 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom_locate"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e3c83c053b0713da60c5b8de47fe8e494fe3ece5267b2f23090a07a053ba8f3"
+dependencies = [
+ "bytecount",
+ "memchr",
+ "nom",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ tracing = ["dep:tracing"]
 
 [dependencies]
 nom = "7.1.3"
+nom_locate = "4.2.0"
 serde = { version = "1.0.214", features = ["derive"] }
 thiserror = "1.0.66"
 tracing = { version = "0.1.40", optional = true }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,8 @@
+use nom::IResult;
 use thiserror::Error;
 
 pub type NixUriResult<T> = Result<T, NixUriError>;
+pub type NixUriIResult<I, T> = IResult<I, T, NixUriError>;
 
 #[derive(Debug, Error, PartialEq)]
 #[non_exhaustive]
@@ -49,6 +51,11 @@ pub enum NixUriError {
     Parser(#[from] nom::Err<(String, nom::error::ErrorKind)>),
     #[error("Servo Url Parsing Error: {0}")]
     ServoUrl(#[from] url::ParseError),
+}
+
+#[derive(Debug, PartialEq)]
+pub enum MyParseErrors<I> {
+    Expected(I, nom::Err<(I, nom::error::ErrorKind)>),
 }
 
 impl From<nom::Err<nom::error::Error<&str>>> for NixUriError {


### PR DESCRIPTION
The default is using noms out-of-the-box errors. these aren't very useful: if we expect a `://` we use `tag("://")`, but if that tag isn't found, it just returns with the input provided, and the `Tag` variant of an error enum. What we want is "starting at offset X, expected `://`, but got `offsetted input`"

- I tried `VerboseError` in combination with the `context` combinator: not ideal, as it keeps the `tag` failure, where in fact we want to _replace_ the generic `Tag` error
- We want to keep the references. Currently, error-results takes `&str` and changes to `String`. Vast majority of the time, maintaining a reference to the error source is not only feasible, but better encapsulaties the business logic: It makes sense for an error to refer directly to the source of the error. A copy infers that it's okay if the thing that caused the error changes, which is inconsistent with the purpose of error information.
- We will want to impl ParseError for our custom error types.
- I like the look of nom-locate, as it gives span information that we will definately be wanting.

swapping to `nom-supreme::tag` these are the benchmarks:

```
     Running benches/bench.rs (target/release/deps/bench-f5902e3daad60bb8)
Gnuplot not found, using plotters backend
simple_uri              time:   [251.63 ns 251.96 ns 252.25 ns]
                        change: [+1.3442% +1.5753% +1.7829%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) low mild

simple_uri_gitlab       time:   [259.87 ns 260.00 ns 260.11 ns]
                        change: [+5.5464% +5.6393% +5.7516%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe

simple_uri_sourcehut    time:   [258.81 ns 258.97 ns 259.13 ns]
                        change: [+0.7594% +0.9131% +1.0538%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

simple_uri_with_params  time:   [393.23 ns 393.31 ns 393.40 ns]
                        change: [-3.2862% -3.1750% -3.0616%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  6 (6.00%) high severe

simple_uri_path         time:   [371.85 ns 372.02 ns 372.18 ns]
                        change: [-2.6204% -2.4508% -2.2836%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild
  2 (2.00%) high severe

```

with this code:

```rust
pub fn parse_sep(input: &str) -> IResult<&str, &str, ErrorTree<&str>> {
    tag("://")(input)
}
#[cfg(test)]
mod tests {
    use super::*;
    #[test]
    fn panic_parse() {
        parse_sep(":/foobar").unwrap();
    }
}
```

we get this error:
```
called `Result::unwrap()` on an `Err` value: Error(Base { location: ":/foobar", kind: Expected(Tag("://")) })
```