### PR TITLE
General cleanup

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -46,21 +46,25 @@ pub enum NixUriError {
     #[error("Nom Error: {0}")]
     Nom(String),
     #[error(transparent)]
-    NomParseError(#[from] nom::Err<nom::error::Error<String>>),
-    #[error(transparent)]
-    Parser(#[from] nom::Err<(String, nom::error::ErrorKind)>),
+    NomParseError(#[from] nom::error::Error<String>),
+    #[error("{} {}", 0.0, 0.1)]
+    Parser((String, nom::error::ErrorKind)),
     #[error("Servo Url Parsing Error: {0}")]
     ServoUrl(#[from] url::ParseError),
 }
 
-impl From<nom::Err<nom::error::Error<&str>>> for NixUriError {
-    fn from(value: nom::Err<nom::error::Error<&str>>) -> Self {
-        Self::NomParseError(value.to_owned())
+impl From<nom::error::Error<&str>> for NixUriError {
+    fn from(value: nom::error::Error<&str>) -> Self {
+        let new_err = nom::error::Error {
+            input: value.input.to_string(),
+            code: value.code,
+        };
+        Self::NomParseError(new_err)
     }
 }
 
-impl From<nom::Err<(&str, nom::error::ErrorKind)>> for NixUriError {
-    fn from(value: nom::Err<(&str, nom::error::ErrorKind)>) -> Self {
-        Self::Parser(value.to_owned())
+impl From<(&str, nom::error::ErrorKind)> for NixUriError {
+    fn from(value: (&str, nom::error::ErrorKind)) -> Self {
+        Self::Parser((value.0.to_string(), value.1))
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+pub(crate) use nom::error::{Error as NomError, ErrorKind as NomErrorKind};
 use thiserror::Error;
 
 pub type NixUriResult<T> = Result<T, NixUriError>;
@@ -46,16 +47,16 @@ pub enum NixUriError {
     #[error("Nom Error: {0}")]
     Nom(String),
     #[error(transparent)]
-    NomParseError(#[from] nom::error::Error<String>),
+    NomParseError(#[from] NomError<String>),
     #[error("{} {}", 0.0, 0.1)]
-    Parser((String, nom::error::ErrorKind)),
+    Parser((String, NomErrorKind)),
     #[error("Servo Url Parsing Error: {0}")]
     ServoUrl(#[from] url::ParseError),
 }
 
-impl From<nom::error::Error<&str>> for NixUriError {
-    fn from(value: nom::error::Error<&str>) -> Self {
-        let new_err = nom::error::Error {
+impl From<NomError<&str>> for NixUriError {
+    fn from(value: NomError<&str>) -> Self {
+        let new_err = NomError {
             input: value.input.to_string(),
             code: value.code,
         };
@@ -63,8 +64,8 @@ impl From<nom::error::Error<&str>> for NixUriError {
     }
 }
 
-impl From<(&str, nom::error::ErrorKind)> for NixUriError {
-    fn from(value: (&str, nom::error::ErrorKind)) -> Self {
+impl From<(&str, NomErrorKind)> for NixUriError {
+    fn from(value: (&str, NomErrorKind)) -> Self {
         Self::Parser((value.0.to_string(), value.1))
     }
 }

--- a/src/flakeref.rs
+++ b/src/flakeref.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use nom::{bytes::complete::tag, combinator::opt, sequence::preceded, IResult};
+use nom::{character::complete::char, combinator::opt, sequence::preceded, IResult};
 use serde::{Deserialize, Serialize};
 
 use crate::error::NixUriError;
@@ -53,7 +53,7 @@ impl FlakeRef {
     }
     pub fn parse(input: &str) -> IResult<&str, Self> {
         let (rest, r#type) = FlakeRefType::parse(input)?;
-        let (rest, params) = opt(preceded(tag("?"), LocationParameters::parse))(rest)?;
+        let (rest, params) = opt(preceded(char('?'), LocationParameters::parse))(rest)?;
         Ok((
             rest,
             Self {

--- a/src/flakeref/fr_type.rs
+++ b/src/flakeref/fr_type.rs
@@ -2,6 +2,7 @@ use std::{fmt::Display, path::Path};
 
 use nom::{
     branch::alt,
+    character::complete::char,
     bytes::complete::{tag, take_till, take_until},
     combinator::{map, opt, peek, rest, verify},
     sequence::preceded,
@@ -72,7 +73,7 @@ impl FlakeRefType {
     }
     pub fn parse_naked(input: &str) -> IResult<&str, &Path> {
         // Check if input starts with `.` or `/`
-        let (is_path, _) = peek(alt((tag("."), tag("/"))))(input)?;
+        let (is_path, _) = peek(alt((char('.'), char('/'))))(input)?;
         let (rest, path_str) = Self::path_parser(is_path)?;
         Ok((rest, Path::new(path_str)))
     }
@@ -123,7 +124,7 @@ impl FlakeRefType {
         use nom::sequence::separated_pair;
         let (_, maybe_explicit_type) = opt(separated_pair(
             take_until::<&str, &str, (&str, nom::error::ErrorKind)>(":"),
-            tag(":"),
+            char(':'),
             rest,
         ))(input)?;
         if let Some((flake_ref_type_str, input)) = maybe_explicit_type {

--- a/src/flakeref/location_params.rs
+++ b/src/flakeref/location_params.rs
@@ -1,9 +1,7 @@
 use std::fmt::Display;
 
 use nom::{
-    branch::alt,
-    bytes::complete::{tag, take_until},
-    combinator::rest,
+    bytes::complete::{tag, take_till, take_until},
     multi::many_m_n,
     sequence::separated_pair,
     IResult,
@@ -93,7 +91,7 @@ impl LocationParameters {
             separated_pair(
                 take_until("="),
                 tag("="),
-                alt((take_until("&"), take_until("#"), rest)),
+                take_till(|c| c == '&' || c == '#'),
             ),
         )(input)?;
 
@@ -120,6 +118,7 @@ impl LocationParameters {
         }
         Ok((rest, params))
     }
+
     pub fn dir(&mut self, dir: Option<String>) -> &mut Self {
         self.dir = dir;
         self

--- a/src/flakeref/location_params.rs
+++ b/src/flakeref/location_params.rs
@@ -1,7 +1,8 @@
 use std::fmt::Display;
 
 use nom::{
-    bytes::complete::{tag, take_till, take_until},
+    bytes::complete::{take_till, take_until},
+    character::complete::char,
     multi::many_m_n,
     sequence::separated_pair,
     IResult,
@@ -90,7 +91,7 @@ impl LocationParameters {
             11,
             separated_pair(
                 take_until("="),
-                tag("="),
+                char('='),
                 take_till(|c| c == '&' || c == '#'),
             ),
         )(input)?;

--- a/src/flakeref/transport_layer.rs
+++ b/src/flakeref/transport_layer.rs
@@ -1,6 +1,9 @@
 use std::fmt::Display;
 
-use nom::{branch::alt, character::complete::char, bytes::complete::tag, combinator::value, sequence::preceded, IResult};
+use nom::{
+    branch::alt, bytes::complete::tag, character::complete::char, combinator::value,
+    sequence::preceded, IResult,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::error::NixUriError;

--- a/src/flakeref/transport_layer.rs
+++ b/src/flakeref/transport_layer.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use nom::{branch::alt, bytes::complete::tag, combinator::value, sequence::preceded, IResult};
+use nom::{branch::alt, character::complete::char, bytes::complete::tag, combinator::value, sequence::preceded, IResult};
 use serde::{Deserialize, Serialize};
 
 use crate::error::NixUriError;
@@ -27,7 +27,7 @@ impl TransportLayer {
         ))(input)
     }
     pub fn plus_parse(input: &str) -> IResult<&str, Self> {
-        preceded(tag("+"), Self::parse)(input)
+        preceded(char('+'), Self::parse)(input)
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,13 +1,12 @@
 use nom::{
-    character::complete::char as n_char,
     branch::alt,
     bytes::complete::take_until,
-    character::complete::anychar,
+    character::complete::{anychar, char as n_char},
     combinator::{opt, rest},
     error::context,
     multi::many_m_n,
     sequence::preceded,
-    IResult,
+    Finish, IResult,
 };
 
 use crate::{
@@ -77,7 +76,7 @@ pub(crate) fn parse_nix_uri(input: &str) -> NixUriResult<FlakeRef> {
         return Err(NixUriError::InvalidUrl(input.into()));
     }
 
-    let (input, params) = parse_params(input)?;
+    let (input, params) = parse_params(input).finish()?;
     let mut flake_ref = FlakeRef::default();
     let flake_ref_type = FlakeRefType::parse_type(input)?;
     flake_ref.r#type(flake_ref_type);
@@ -109,7 +108,7 @@ pub(crate) fn is_file(input: &str) -> bool {
 
 // Parse the transport type itself
 pub(crate) fn parse_transport_type(input: &str) -> Result<TransportLayer, NixUriError> {
-    let (_, input) = parse_from_transport_type(input)?;
+    let (_, input) = parse_from_transport_type(input).finish()?;
     TryInto::<TransportLayer>::try_into(input)
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5,7 +5,7 @@ use nom::{
     combinator::{opt, rest},
     error::context,
     multi::many_m_n,
-    sequence::preceded,
+    sequence::{preceded, separated_pair},
     Finish, IResult,
 };
 
@@ -18,8 +18,6 @@ use crate::{
 /// Take all that is behind the "?" tag
 /// Return everything prior as not parsed
 pub(crate) fn parse_params(input: &str) -> IResult<&str, Option<LocationParameters>> {
-    use nom::sequence::separated_pair;
-
     // This is the inverse of the general control flow
     let (input, maybe_flake_type) = opt(take_until("?"))(input)?;
 


### PR DESCRIPTION
Main items:

- uses `char('x')` in place of `tag("x")`. This will become particularly useful when we start using `VerboseError`*
- slight refactor of parse-repo-ref/rev
- use of `finish()` to remove the `nom::Err` enum-wrapper of the actual error

* I plan to migrate to `IResult<..., ..., VerboseError<&str>>`. it gives nice, contextual errors. With the `char` parser, it even points at a location, stating what was expected.