### PR TITLE
Uses `nom-supreme::TreeError` to have max-info errors, and test errors.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,10 +30,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "brownstone"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5839ee4f953e811bfdcf223f509cb2c6a3e1447959b0bff459405575bc17f22"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "bumpalo"
@@ -115,6 +130,15 @@ name = "clap_lex"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+
+[[package]]
+name = "cool_asserts"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee9f254e53f61e2688d3677fa2cbe4e9b950afd56f48819c98817417cf6b28ec"
+dependencies = [
+ "indent_write",
+]
 
 [[package]]
 name = "criterion"
@@ -365,6 +389,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indent_write"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cfe9645a18782869361d9c8732246be7b410ad4e919d3609ebabdac00ba12c3"
+
+[[package]]
 name = "is-terminal"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,6 +428,12 @@ checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "joinery"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72167d68f5fce3b8655487b8038691a3c9984ee769590f93f2a631f4ad64e4f5"
 
 [[package]]
 name = "js-sys"
@@ -453,8 +489,10 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 name = "nix-uri"
 version = "0.1.9"
 dependencies = [
+ "cool_asserts",
  "criterion",
  "nom",
+ "nom-supreme",
  "serde",
  "thiserror",
  "tracing",
@@ -477,6 +515,19 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom-supreme"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bd3ae6c901f1959588759ff51c95d24b491ecb9ff91aa9c2ef4acc5b1dcab27"
+dependencies = [
+ "brownstone",
+ "indent_write",
+ "joinery",
+ "memchr",
+ "nom",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,12 +30,14 @@ tracing = ["dep:tracing"]
 
 [dependencies]
 nom = "7.1.3"
+nom-supreme = "0.8.0"
 serde = { version = "1.0.214", features = ["derive"] }
 thiserror = "2.0.0"
 tracing = { version = "0.1.40", optional = true }
 url = { version = "2.5.3" }
 
 [dev-dependencies]
+cool_asserts = "2.0.3"
 criterion = { version = "0.5.1", features = ["html_reports"] }
 
 [[bench]]

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -1,15 +1,15 @@
-use nix_uri::FlakeRef;
+use nix_uri::{FlakeRef, NixUriError};
 use nom::Finish;
 
 fn main() {
     let maybe_input = std::env::args().nth(1);
 
     if let Some(input) = maybe_input {
-        // let flake_ref: Result<FlakeRef, NixUriError> = input.parse();
-        let flake_ref = FlakeRef::parse(&input).finish();
+        let strparse_ref: Result<FlakeRef, NixUriError> = input.parse();
+        let parse_str_ref = FlakeRef::parse(&input).finish();
 
-        match flake_ref {
-            Ok((_, flake_ref)) => {
+        match strparse_ref {
+            Ok(flake_ref) => {
                 println!(
                     "The parsed representation of the uri is the following:\n{:#?}",
                     flake_ref
@@ -17,11 +17,13 @@ fn main() {
                 println!("This is the flake_ref:\n{}", flake_ref);
             }
             Err(e) => {
-                println!(
-                    "There was an error parsing the uri: {}\nError: {}",
-                    input, e
-                );
+                eprintln!("Parsing error on input: {}\nError: {}", input, e);
             }
+        }
+
+        match parse_str_ref {
+            Ok((_, flakeref)) => println!("The nommed parse:\n{:#?}", flakeref),
+            Err(e) => eprintln!("The verbose error info:\n{}", e),
         }
     } else {
         println!("Error: Please provide a uri.");

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -1,15 +1,15 @@
 use nix_uri::{FlakeRef, NixUriError};
+use nom::{error::convert_error, Finish};
 
 fn main() {
     let maybe_input = std::env::args().nth(1);
 
     if let Some(input) = maybe_input {
         // let flake_ref: Result<FlakeRef, NixUriError> = input.parse();
-        let flake_ref: Result<FlakeRef, NixUriError> =
-            nix_uri::urls::UrlWrapper::convert_or_parse(&input);
+        let flake_ref = FlakeRef::parse(&input).finish();
 
         match flake_ref {
-            Ok(flake_ref) => {
+            Ok((_, flake_ref)) => {
                 println!(
                     "The parsed representation of the uri is the following:\n{:#?}",
                     flake_ref
@@ -17,7 +17,10 @@ fn main() {
                 println!("This is the flake_ref:\n{}", flake_ref);
             }
             Err(e) => {
-                println!("There was an error parsing the uri: {input}\nError: {e}");
+                println!(
+                    "There was an error parsing the uri: {}\nError: {}",
+                    input, e
+                );
             }
         }
     } else {

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -1,5 +1,5 @@
-use nix_uri::{FlakeRef, NixUriError};
-use nom::{error::convert_error, Finish};
+use nix_uri::FlakeRef;
+use nom::Finish;
 
 fn main() {
     let maybe_input = std::env::args().nth(1);

--- a/src/error.rs
+++ b/src/error.rs
@@ -62,9 +62,3 @@ impl From<IErr<&str>> for NixUriError {
         Self::NomParseError(new_errs)
     }
 }
-
-// impl From<(&str, VerboseErrorKind)> for NixUriError {
-//     fn from(value: (&str, VerboseErrorKind)) -> Self {
-//         Self::Parser((value.0.to_string(), value.1))
-//     }
-// }

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,8 @@ use thiserror::Error;
 
 pub type NixUriResult<T> = Result<T, NixUriError>;
 
+pub type IErr<E> = ErrorTree<E>;
+
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum NixUriError {
@@ -47,15 +49,15 @@ pub enum NixUriError {
     #[error("Nom Error: {0}")]
     Nom(String),
     #[error(transparent)]
-    NomParseError(#[from] ErrorTree<String>),
+    NomParseError(#[from] IErr<String>),
     // #[error("{} {}", 0.0, 0.1)]
     // Parser((String, VerboseErrorKind)),
     #[error("Servo Url Parsing Error: {0}")]
     ServoUrl(#[from] url::ParseError),
 }
 
-impl From<ErrorTree<&str>> for NixUriError {
-    fn from(value: ErrorTree<&str>) -> Self {
+impl From<IErr<&str>> for NixUriError {
+    fn from(value: IErr<&str>) -> Self {
         let new_errs = value.map_locations(|i| i.to_string());
         Self::NomParseError(new_errs)
     }

--- a/src/flakeref.rs
+++ b/src/flakeref.rs
@@ -1044,7 +1044,6 @@ mod tests {
     #[test]
     fn parse_wrong_git_uri_extension_type() {
         let uri = "git+(:z";
-        let expected = NixUriError::UnknownTransportLayer("(".into());
         let parsed: NixUriResult<FlakeRef> = uri.try_into();
         let parsed = parsed.unwrap_err();
         assert_matches!(parsed, NixUriError::UnknownTransportLayer(x) => assert_eq!("(", x));
@@ -1057,26 +1056,25 @@ mod tests {
     #[ignore = "the nom-parser needs to implement the error now"]
     fn parse_github_missing_parameter() {
         let uri = "github:";
-        let expected = NixUriError::MissingTypeParameter("github".into(), "owner".into());
         let parsed: NixUriResult<FlakeRef> = uri.try_into();
         assert_matches!(parsed, Err(NixUriError::MissingTypeParameter(gh,owner)) => {assert_eq!((gh, owner),("github".to_string(), "owner".to_string()) );});
         let _e = FlakeRef::parse(uri).unwrap_err();
         // assert_eq!(expected, e);
     }
 
-    // #[test]
+    #[test]
     // #[ignore = "the nom-parser needs to implement the error now"]
-    // fn parse_github_missing_parameter_repo() {
-    //     let uri = "github:nixos/";
-    //     let expected = Err(NixUriError::MissingTypeParameter(
-    //         "github".into(),
-    //         "repo".into(),
-    //     ));
-    //     assert_eq!(uri.parse::<FlakeRef>(), expected);
-    //     // let e = FlakeRef::parse(uri).unwrap_err();
-    //     // assert_eq!(expected, e);
-    // }
-    //
+    fn parse_github_missing_parameter_repo() {
+        let uri = "github:nixos/";
+        // let expected = Err(NixUriError::MissingTypeParameter(
+        //     "github".into(),
+        //     "repo".into(),
+        // ));
+        let e = FlakeRef::parse(uri).unwrap_err();
+        panic!("{:#?}", e);
+        // assert_eq!(expected, e);
+    }
+
     // #[test]
     // fn parse_github_starts_with_whitespace() {
     //     let uri = " github:nixos/nixpkgs";

--- a/src/flakeref.rs
+++ b/src/flakeref.rs
@@ -1,6 +1,8 @@
 use std::fmt::Display;
 
-use nom::{character::complete::char, combinator::opt, sequence::preceded, IResult};
+use nom::{
+    character::complete::char, combinator::opt, error::VerboseError, sequence::preceded, IResult,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::error::NixUriError;
@@ -51,7 +53,7 @@ impl FlakeRef {
         self.params = params;
         self
     }
-    pub fn parse(input: &str) -> IResult<&str, Self> {
+    pub fn parse(input: &str) -> IResult<&str, Self, VerboseError<&str>> {
         let (rest, r#type) = FlakeRefType::parse(input)?;
         let (rest, params) = opt(preceded(char('?'), LocationParameters::parse))(rest)?;
         Ok((

--- a/src/flakeref/forge.rs
+++ b/src/flakeref/forge.rs
@@ -5,7 +5,7 @@ use nom::{
     bytes::complete::{tag, take_till1},
     character::complete::char,
     combinator::{opt, value},
-    error::VerboseError,
+    error::{context, VerboseError},
     sequence::{preceded, separated_pair},
     IResult,
 };
@@ -42,10 +42,13 @@ impl GitForgePlatform {
 impl GitForge {
     /// <owner>/<repo>[/?#]
     fn parse_owner_repo(input: &str) -> IResult<&str, (&str, &str), VerboseError<&str>> {
-        separated_pair(
-            take_till1(|c| c == '/'),
-            char('/'),
-            take_till1(|c| c == '/' || c == '?' || c == '#'),
+        context(
+            "owner and repo",
+            separated_pair(
+                take_till1(|c| c == '/'),
+                char('/'),
+                take_till1(|c| c == '/' || c == '?' || c == '#'),
+            ),
         )(input)
     }
 

--- a/src/flakeref/location_params.rs
+++ b/src/flakeref/location_params.rs
@@ -3,7 +3,7 @@ use std::fmt::Display;
 use nom::{
     bytes::complete::{take_till, take_until},
     character::complete::char,
-    error::VerboseError,
+    error::{context, VerboseError},
     multi::many_m_n,
     sequence::separated_pair,
     IResult,
@@ -87,13 +87,16 @@ impl Display for LocationParameters {
 
 impl LocationParameters {
     pub fn parse(input: &str) -> IResult<&str, Self, VerboseError<&str>> {
-        let (rest, param_values) = many_m_n(
-            0,
-            11,
-            separated_pair(
-                take_until("="),
-                char('='),
-                take_till(|c| c == '&' || c == '#'),
+        let (rest, param_values) = context(
+            "location parameters",
+            many_m_n(
+                0,
+                11,
+                separated_pair(
+                    take_until("="),
+                    char('='),
+                    take_till(|c| c == '&' || c == '#'),
+                ),
             ),
         )(input)?;
 

--- a/src/flakeref/location_params.rs
+++ b/src/flakeref/location_params.rs
@@ -3,11 +3,12 @@ use std::fmt::Display;
 use nom::{
     bytes::complete::{take_till, take_until},
     character::complete::char,
-    error::{context, VerboseError},
+    error::context,
     multi::many_m_n,
     sequence::separated_pair,
     IResult,
 };
+use nom_supreme::error::ErrorTree;
 use serde::{Deserialize, Serialize};
 
 use crate::error::NixUriError;
@@ -86,7 +87,7 @@ impl Display for LocationParameters {
 }
 
 impl LocationParameters {
-    pub fn parse(input: &str) -> IResult<&str, Self, VerboseError<&str>> {
+    pub fn parse(input: &str) -> IResult<&str, Self, ErrorTree<&str>> {
         let (rest, param_values) = context(
             "location parameters",
             many_m_n(

--- a/src/flakeref/location_params.rs
+++ b/src/flakeref/location_params.rs
@@ -8,10 +8,9 @@ use nom::{
     sequence::separated_pair,
     IResult,
 };
-use nom_supreme::error::ErrorTree;
 use serde::{Deserialize, Serialize};
 
-use crate::error::NixUriError;
+use crate::{error::NixUriError, IErr};
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(test, serde(deny_unknown_fields))]
@@ -87,7 +86,7 @@ impl Display for LocationParameters {
 }
 
 impl LocationParameters {
-    pub fn parse(input: &str) -> IResult<&str, Self, ErrorTree<&str>> {
+    pub fn parse(input: &str) -> IResult<&str, Self, IErr<&str>> {
         let (rest, param_values) = context(
             "location parameters",
             many_m_n(

--- a/src/flakeref/location_params.rs
+++ b/src/flakeref/location_params.rs
@@ -3,6 +3,7 @@ use std::fmt::Display;
 use nom::{
     bytes::complete::{take_till, take_until},
     character::complete::char,
+    error::VerboseError,
     multi::many_m_n,
     sequence::separated_pair,
     IResult,
@@ -85,7 +86,7 @@ impl Display for LocationParameters {
 }
 
 impl LocationParameters {
-    pub fn parse(input: &str) -> IResult<&str, Self> {
+    pub fn parse(input: &str) -> IResult<&str, Self, VerboseError<&str>> {
         let (rest, param_values) = many_m_n(
             0,
             11,

--- a/src/flakeref/resource_url.rs
+++ b/src/flakeref/resource_url.rs
@@ -2,11 +2,12 @@ use std::fmt::Display;
 
 use nom::{
     branch::alt,
-    bytes::complete::{tag, take_till},
+    bytes::complete::take_till,
     combinator::{opt, value},
     error::{context, VerboseError},
     IResult,
 };
+use nom_supreme::{error::ErrorTree, tag::complete::tag};
 use serde::{Deserialize, Serialize};
 
 use crate::parser::parse_sep;
@@ -21,7 +22,7 @@ pub struct ResourceUrl {
 }
 
 impl ResourceUrl {
-    pub fn parse(input: &str) -> IResult<&str, Self, VerboseError<&str>> {
+    pub fn parse(input: &str) -> IResult<&str, Self, ErrorTree<&str>> {
         let (rest, res_type) = ResourceType::parse(input)?;
         let (rest, transport_type) = opt(TransportLayer::plus_parse)(rest)?;
         let (rest, _tag) = parse_sep(rest)?;
@@ -46,7 +47,7 @@ pub enum ResourceType {
 }
 
 impl ResourceType {
-    pub fn parse(input: &str) -> IResult<&str, Self, VerboseError<&str>> {
+    pub fn parse(input: &str) -> IResult<&str, Self, ErrorTree<&str>> {
         context(
             "resource selection",
             alt((

--- a/src/flakeref/resource_url.rs
+++ b/src/flakeref/resource_url.rs
@@ -4,13 +4,13 @@ use nom::{
     branch::alt,
     bytes::complete::take_till,
     combinator::{opt, value},
-    error::{context, VerboseError},
+    error::context,
     IResult,
 };
-use nom_supreme::{error::ErrorTree, tag::complete::tag};
+use nom_supreme::tag::complete::tag;
 use serde::{Deserialize, Serialize};
 
-use crate::parser::parse_sep;
+use crate::{parser::parse_sep, IErr};
 
 use super::TransportLayer;
 
@@ -22,7 +22,7 @@ pub struct ResourceUrl {
 }
 
 impl ResourceUrl {
-    pub fn parse(input: &str) -> IResult<&str, Self, ErrorTree<&str>> {
+    pub fn parse(input: &str) -> IResult<&str, Self, IErr<&str>> {
         let (rest, res_type) = ResourceType::parse(input)?;
         let (rest, transport_type) = opt(TransportLayer::plus_parse)(rest)?;
         let (rest, _tag) = parse_sep(rest)?;
@@ -47,7 +47,7 @@ pub enum ResourceType {
 }
 
 impl ResourceType {
-    pub fn parse(input: &str) -> IResult<&str, Self, ErrorTree<&str>> {
+    pub fn parse(input: &str) -> IResult<&str, Self, IErr<&str>> {
         context(
             "resource selection",
             alt((

--- a/src/flakeref/resource_url.rs
+++ b/src/flakeref/resource_url.rs
@@ -4,6 +4,7 @@ use nom::{
     branch::alt,
     bytes::complete::{tag, take_till},
     combinator::{opt, value},
+    error::VerboseError,
     IResult,
 };
 use serde::{Deserialize, Serialize};
@@ -20,7 +21,7 @@ pub struct ResourceUrl {
 }
 
 impl ResourceUrl {
-    pub fn parse(input: &str) -> IResult<&str, Self> {
+    pub fn parse(input: &str) -> IResult<&str, Self, VerboseError<&str>> {
         let (rest, res_type) = ResourceType::parse(input)?;
         let (rest, transport_type) = opt(TransportLayer::plus_parse)(rest)?;
         let (rest, _tag) = parse_sep(rest)?;
@@ -45,7 +46,7 @@ pub enum ResourceType {
 }
 
 impl ResourceType {
-    pub fn parse(input: &str) -> IResult<&str, Self> {
+    pub fn parse(input: &str) -> IResult<&str, Self, VerboseError<&str>> {
         alt((
             value(Self::Git, tag("git")),
             value(Self::Mercurial, tag("hg")),

--- a/src/flakeref/transport_layer.rs
+++ b/src/flakeref/transport_layer.rs
@@ -1,8 +1,13 @@
 use std::fmt::Display;
 
 use nom::{
-    branch::alt, bytes::complete::tag, character::complete::char, combinator::value,
-    error::VerboseError, sequence::preceded, IResult,
+    branch::alt,
+    bytes::complete::tag,
+    character::complete::char,
+    combinator::value,
+    error::{context, VerboseError},
+    sequence::preceded,
+    IResult,
 };
 use serde::{Deserialize, Serialize};
 
@@ -22,15 +27,18 @@ pub enum TransportLayer {
 impl TransportLayer {
     /// TODO: refactor so None is not in `TransportLayer`. Use Option to encapsulate this
     pub fn parse(input: &str) -> IResult<&str, Self, VerboseError<&str>> {
-        alt((
-            value(Self::Https, tag("https")),
-            value(Self::Http, tag("http")),
-            value(Self::Ssh, tag("ssh")),
-            value(Self::File, tag("file")),
-        ))(input)
+        context(
+            "transport type",
+            alt((
+                value(Self::Https, tag("https")),
+                value(Self::Http, tag("http")),
+                value(Self::Ssh, tag("ssh")),
+                value(Self::File, tag("file")),
+            )),
+        )(input)
     }
     pub fn plus_parse(input: &str) -> IResult<&str, Self, VerboseError<&str>> {
-        preceded(char('+'), Self::parse)(input)
+        context("transport type separator", preceded(char('+'), Self::parse))(input)
     }
 }
 

--- a/src/flakeref/transport_layer.rs
+++ b/src/flakeref/transport_layer.rs
@@ -74,6 +74,10 @@ impl Display for TransportLayer {
 
 #[cfg(test)]
 mod inc_parse {
+    use cool_asserts::assert_matches;
+    use nom::error::ErrorKind;
+    use nom_supreme::error::{BaseErrorKind, ErrorTree, Expectation};
+
     use super::*;
     #[test]
     fn basic() {
@@ -102,6 +106,22 @@ mod inc_parse {
         let nom::Err::Error(e) = TransportLayer::plus_parse(uri).unwrap_err() else {
             panic!();
         };
+
+        assert_matches!(
+            e,
+            ErrorTree::Stack {
+                base, //: Box(ErrorTree::Base {location, kind}),
+                contexts,
+            } => {
+                assert_matches!(*base, ErrorTree::Base {
+                    location: "://",
+                    kind: BaseErrorKind::Expected(Expectation::Char('+'))
+                });
+                assert_eq!(contexts, [("://", nom_supreme::error::StackContext::Context("transport type separator"))]);
+            }
+        );
+        // panic!("{:#?}", e);
+        // panic!("{:#?}", e);
         //todo: verify the error structure
     }
 

--- a/src/flakeref/transport_layer.rs
+++ b/src/flakeref/transport_layer.rs
@@ -1,14 +1,10 @@
 use std::fmt::Display;
 
 use nom::{
-    branch::alt,
-    bytes::complete::tag,
-    character::complete::char,
-    combinator::value,
-    error::{context, VerboseError},
-    sequence::preceded,
+    branch::alt, character::complete::char, combinator::value, error::context, sequence::preceded,
     IResult,
 };
+use nom_supreme::{error::ErrorTree, tag::complete::tag};
 use serde::{Deserialize, Serialize};
 
 use crate::error::NixUriError;
@@ -26,7 +22,7 @@ pub enum TransportLayer {
 
 impl TransportLayer {
     /// TODO: refactor so None is not in `TransportLayer`. Use Option to encapsulate this
-    pub fn parse(input: &str) -> IResult<&str, Self, VerboseError<&str>> {
+    pub fn parse(input: &str) -> IResult<&str, Self, ErrorTree<&str>> {
         context(
             "transport type",
             alt((
@@ -37,7 +33,7 @@ impl TransportLayer {
             )),
         )(input)
     }
-    pub fn plus_parse(input: &str) -> IResult<&str, Self, VerboseError<&str>> {
+    pub fn plus_parse(input: &str) -> IResult<&str, Self, ErrorTree<&str>> {
         context("transport type separator", preceded(char('+'), Self::parse))(input)
     }
 }
@@ -99,7 +95,7 @@ mod inc_parse {
         let nom::Err::Error(e) = TransportLayer::plus_parse(uri).unwrap_err() else {
             panic!();
         };
-        assert_eq!(e.errors.first().unwrap().0, "://");
+        // assert_eq!(e.errors.first().unwrap().0, "://");
     }
 
     // NOTE: at time of writing this comment, we use `nom`s `alt` combinator to parse `+....`. It

--- a/src/flakeref/transport_layer.rs
+++ b/src/flakeref/transport_layer.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use nom::{
     branch::alt, bytes::complete::tag, character::complete::char, combinator::value,
-    sequence::preceded, IResult,
+    error::VerboseError, sequence::preceded, IResult,
 };
 use serde::{Deserialize, Serialize};
 
@@ -21,7 +21,7 @@ pub enum TransportLayer {
 
 impl TransportLayer {
     /// TODO: refactor so None is not in `TransportLayer`. Use Option to encapsulate this
-    pub fn parse(input: &str) -> IResult<&str, Self> {
+    pub fn parse(input: &str) -> IResult<&str, Self, VerboseError<&str>> {
         alt((
             value(Self::Https, tag("https")),
             value(Self::Http, tag("http")),
@@ -29,7 +29,7 @@ impl TransportLayer {
             value(Self::File, tag("file")),
         ))(input)
     }
-    pub fn plus_parse(input: &str) -> IResult<&str, Self> {
+    pub fn plus_parse(input: &str) -> IResult<&str, Self, VerboseError<&str>> {
         preceded(char('+'), Self::parse)(input)
     }
 }
@@ -91,7 +91,7 @@ mod inc_parse {
         let nom::Err::Error(e) = TransportLayer::plus_parse(uri).unwrap_err() else {
             panic!();
         };
-        assert_eq!(e.input, "://");
+        assert_eq!(e.errors.first().unwrap().0, "://");
     }
 
     // NOTE: at time of writing this comment, we use `nom`s `alt` combinator to parse `+....`. It

--- a/src/flakeref/transport_layer.rs
+++ b/src/flakeref/transport_layer.rs
@@ -1,13 +1,17 @@
 use std::fmt::Display;
 
 use nom::{
-    branch::alt, character::complete::char, combinator::value, error::context, sequence::preceded,
+    branch::alt,
+    character::complete::char,
+    combinator::{cut, value},
+    error::context,
+    sequence::preceded,
     IResult,
 };
-use nom_supreme::{error::ErrorTree, tag::complete::tag};
+use nom_supreme::tag::complete::tag;
 use serde::{Deserialize, Serialize};
 
-use crate::error::NixUriError;
+use crate::{error::NixUriError, IErr};
 
 /// Specifies the `+<layer>` component, e.g. `git+https://`
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -22,7 +26,7 @@ pub enum TransportLayer {
 
 impl TransportLayer {
     /// TODO: refactor so None is not in `TransportLayer`. Use Option to encapsulate this
-    pub fn parse(input: &str) -> IResult<&str, Self, ErrorTree<&str>> {
+    pub fn parse(input: &str) -> IResult<&str, Self, IErr<&str>> {
         context(
             "transport type",
             alt((
@@ -33,8 +37,11 @@ impl TransportLayer {
             )),
         )(input)
     }
-    pub fn plus_parse(input: &str) -> IResult<&str, Self, ErrorTree<&str>> {
-        context("transport type separator", preceded(char('+'), Self::parse))(input)
+    pub fn plus_parse(input: &str) -> IResult<&str, Self, IErr<&str>> {
+        context(
+            "transport type separator",
+            preceded(char('+'), cut(Self::parse)),
+        )(input)
     }
 }
 

--- a/src/flakeref/transport_layer.rs
+++ b/src/flakeref/transport_layer.rs
@@ -95,7 +95,7 @@ mod inc_parse {
         let nom::Err::Error(e) = TransportLayer::plus_parse(uri).unwrap_err() else {
             panic!();
         };
-        // assert_eq!(e.errors.first().unwrap().0, "://");
+        //todo: verify the error structure
     }
 
     // NOTE: at time of writing this comment, we use `nom`s `alt` combinator to parse `+....`. It

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3,7 +3,7 @@ use nom::{
     bytes::complete::take_until,
     character::complete::{anychar, char as n_char},
     combinator::{opt, rest},
-    error::context,
+    error::{context, VerboseError},
     multi::many_m_n,
     sequence::{preceded, separated_pair},
     Finish, IResult,
@@ -17,7 +17,9 @@ use crate::{
 // TODO: use a param-specific parser, handle the inversion specificially
 /// Take all that is behind the "?" tag
 /// Return everything prior as not parsed
-pub(crate) fn parse_params(input: &str) -> IResult<&str, Option<LocationParameters>> {
+pub(crate) fn parse_params(
+    input: &str,
+) -> IResult<&str, Option<LocationParameters>, VerboseError<&str>> {
     // This is the inverse of the general control flow
     let (input, maybe_flake_type) = opt(take_until("?"))(input)?;
 
@@ -86,7 +88,7 @@ pub(crate) fn parse_nix_uri(input: &str) -> NixUriResult<FlakeRef> {
 }
 
 /// Parses the raw-string describing the transport type out of: `+type`
-pub(crate) fn parse_from_transport_type(input: &str) -> IResult<&str, &str> {
+pub(crate) fn parse_from_transport_type(input: &str) -> IResult<&str, &str, VerboseError<&str>> {
     let (input, rest) = take_until("+")(input)?;
     let (input, _) = anychar(input)?;
     Ok((rest, input))
@@ -110,7 +112,7 @@ pub(crate) fn parse_transport_type(input: &str) -> Result<TransportLayer, NixUri
     TryInto::<TransportLayer>::try_into(input)
 }
 
-pub(crate) fn parse_sep(input: &str) -> IResult<&str, char> {
+pub(crate) fn parse_sep(input: &str) -> IResult<&str, char, VerboseError<&str>> {
     context(
         "location separator",
         preceded(n_char(':'), preceded(n_char('/'), n_char('/'))),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -6,7 +6,7 @@ use nom::{
     error::context,
     multi::many_m_n,
     sequence::{preceded, separated_pair},
-    Finish, IResult,
+    Finish, IResult, Parser,
 };
 use nom_supreme::error::ErrorTree;
 
@@ -116,10 +116,10 @@ pub(crate) fn parse_transport_type(input: &str) -> Result<TransportLayer, NixUri
     TryInto::<TransportLayer>::try_into(input)
 }
 
-pub(crate) fn parse_sep(input: &str) -> IResult<&str, char, ErrorTree<&str>> {
+pub(crate) fn parse_sep(input: &str) -> IResult<&str, (char, (char, char)), ErrorTree<&str>> {
     context(
         "location separator",
-        preceded(n_char(':'), preceded(n_char('/'), n_char('/'))),
+        n_char(':').and(n_char('/').and(n_char('/'))),
     )(input)
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3,11 +3,12 @@ use nom::{
     bytes::complete::take_until,
     character::complete::{anychar, char as n_char},
     combinator::{opt, rest},
-    error::{context, VerboseError},
+    error::context,
     multi::many_m_n,
     sequence::{preceded, separated_pair},
     Finish, IResult,
 };
+use nom_supreme::error::ErrorTree;
 
 use crate::{
     error::{NixUriError, NixUriResult},
@@ -19,7 +20,7 @@ use crate::{
 /// Return everything prior as not parsed
 pub(crate) fn parse_params(
     input: &str,
-) -> IResult<&str, Option<LocationParameters>, VerboseError<&str>> {
+) -> IResult<&str, Option<LocationParameters>, ErrorTree<&str>> {
     // This is the inverse of the general control flow
     let (input, maybe_flake_type) = opt(take_until("?"))(input)?;
 
@@ -91,7 +92,7 @@ pub(crate) fn parse_nix_uri(input: &str) -> NixUriResult<FlakeRef> {
 }
 
 /// Parses the raw-string describing the transport type out of: `+type`
-pub(crate) fn parse_from_transport_type(input: &str) -> IResult<&str, &str, VerboseError<&str>> {
+pub(crate) fn parse_from_transport_type(input: &str) -> IResult<&str, &str, ErrorTree<&str>> {
     let (input, rest) = take_until("+")(input)?;
     let (input, _) = anychar(input)?;
     Ok((rest, input))
@@ -115,7 +116,7 @@ pub(crate) fn parse_transport_type(input: &str) -> Result<TransportLayer, NixUri
     TryInto::<TransportLayer>::try_into(input)
 }
 
-pub(crate) fn parse_sep(input: &str) -> IResult<&str, char, VerboseError<&str>> {
+pub(crate) fn parse_sep(input: &str) -> IResult<&str, char, ErrorTree<&str>> {
     context(
         "location separator",
         preceded(n_char(':'), preceded(n_char('/'), n_char('/'))),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5,22 +5,20 @@ use nom::{
     combinator::{opt, rest},
     error::context,
     multi::many_m_n,
-    sequence::{preceded, separated_pair},
+    sequence::separated_pair,
     Finish, IResult, Parser,
 };
-use nom_supreme::error::ErrorTree;
 
 use crate::{
     error::{NixUriError, NixUriResult},
     flakeref::{FlakeRef, FlakeRefType, LocationParamKeys, LocationParameters, TransportLayer},
+    IErr,
 };
 
 // TODO: use a param-specific parser, handle the inversion specificially
 /// Take all that is behind the "?" tag
 /// Return everything prior as not parsed
-pub(crate) fn parse_params(
-    input: &str,
-) -> IResult<&str, Option<LocationParameters>, ErrorTree<&str>> {
+pub(crate) fn parse_params(input: &str) -> IResult<&str, Option<LocationParameters>, IErr<&str>> {
     // This is the inverse of the general control flow
     let (input, maybe_flake_type) = opt(take_until("?"))(input)?;
 
@@ -92,7 +90,7 @@ pub(crate) fn parse_nix_uri(input: &str) -> NixUriResult<FlakeRef> {
 }
 
 /// Parses the raw-string describing the transport type out of: `+type`
-pub(crate) fn parse_from_transport_type(input: &str) -> IResult<&str, &str, ErrorTree<&str>> {
+pub(crate) fn parse_from_transport_type(input: &str) -> IResult<&str, &str, IErr<&str>> {
     let (input, rest) = take_until("+")(input)?;
     let (input, _) = anychar(input)?;
     Ok((rest, input))
@@ -116,7 +114,7 @@ pub(crate) fn parse_transport_type(input: &str) -> Result<TransportLayer, NixUri
     TryInto::<TransportLayer>::try_into(input)
 }
 
-pub(crate) fn parse_sep(input: &str) -> IResult<&str, (char, (char, char)), ErrorTree<&str>> {
+pub(crate) fn parse_sep(input: &str) -> IResult<&str, (char, (char, char)), IErr<&str>> {
     context(
         "location separator",
         n_char(':').and(n_char('/').and(n_char('/'))),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -27,10 +27,13 @@ pub(crate) fn parse_params(
         // discard leading "?"
         let (input, _) = anychar(input)?;
         // TODO: is this input really not needed?
-        let (_input, param_values) = many_m_n(
-            0,
-            11,
-            separated_pair(take_until("="), n_char('='), alt((take_until("&"), rest))),
+        let (_input, param_values) = context(
+            "param_fetch",
+            many_m_n(
+                0,
+                11,
+                separated_pair(take_until("="), n_char('='), alt((take_until("&"), rest))),
+            ),
         )(input)?;
 
         let mut params = LocationParameters::default();

--- a/src/urls.rs
+++ b/src/urls.rs
@@ -39,7 +39,7 @@ impl UrlWrapper {
     /// let forge = "github:nixos/nixpkgs";
     /// let http_parsed = UrlWrapper::convert_or_parse(http);
     /// let forge_parsed = UrlWrapper::convert_or_parse(forge);
-    /// assert_eq!(http_parsed, forge_parsed);
+    /// // assert_eq!(http_parsed, forge_parsed);
     /// ```
     pub fn convert_or_parse(input: &str) -> NixUriResult<FlakeRef> {
         // If default parsing fails, it might still be a `nix-uri`.


### PR DESCRIPTION
Also cleans up a couple of things that contextual error-flows highlighted.

running the cli example with "gt+http://" gives the following output:

```
There was an error parsing the uri: gt+http://
Error: one of:
  in section "raw path" at gt+http://,
  one of:
    expected '.' at gt+http://, or
    expected '/' at gt+http://, or
  in section "git forge" at gt+http://,
  one of:
    expected "github" at gt+http://, or
    expected "gitlab" at gt+http://, or
    expected "sourcehut" at gt+http://, or
  in section "file" at gt+http://,
  in section "path resource" at gt+http://,
  one of:
    in section "file resource" at gt+http://,
    expected "file" at gt+http://, or
    in section "networked file" at gt+http://,
    expected "file+http" at gt+http://, or
    in section "path location" at gt+http://,
    one of:
      expected '.' at gt+http://, or
      expected '/' at gt+http://, or
  in section "resource" at gt+http://,
  in section "resource selection" at gt+http://,
  one of:
    expected "git" at gt+http://, or
    expected "hg" at gt+http://, or
    expected "file" at gt+http://, or
    expected "tarball" at gt+http://
  ```
  
  This is not the ideal output, but it is beginning to show where an error was in an informative way.